### PR TITLE
Use correct key when looking up cached image.

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -28,6 +28,10 @@ func Image(str string) *ebiten.Image {
 	ebitenImagesM.Lock()
 	defer ebitenImagesM.Unlock()
 
+	if img, ok := ebitenImages[str]; ok {
+		return img
+	}
+
 	path := "image/emoji_u"
 	for i, r := range str {
 		if i > 0 {
@@ -36,10 +40,6 @@ func Image(str string) *ebiten.Image {
 		path += fmt.Sprintf("%x", r)
 	}
 	path += ".png"
-
-	if img, ok := ebitenImages[path]; ok {
-		return img
-	}
 
 	f, err := pngImages.Open(path)
 	if err != nil {


### PR DESCRIPTION
Previously, this was looking up `path` but caching `str`. Bumped this up
towards the top and continued using `str`. Let me know if you want to
continue using `path` and I can instead change this to cache `path`.